### PR TITLE
Fix slug and improve carousel markers

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,6 +11,7 @@
 				"@sveltejs/adapter-auto": "^6.0.0",
 				"@sveltejs/kit": "^2.16.0",
 				"@sveltejs/vite-plugin-svelte": "^5.0.0",
+				"@types/node": "^22.15.30",
 				"prettier": "^3.4.2",
 				"prettier-plugin-svelte": "^3.3.3",
 				"svelte": "^5.0.0",
@@ -904,6 +905,16 @@
 			"dev": true,
 			"license": "MIT"
 		},
+		"node_modules/@types/node": {
+			"version": "22.15.30",
+			"resolved": "https://registry.npmjs.org/@types/node/-/node-22.15.30.tgz",
+			"integrity": "sha512-6Q7lr06bEHdlfplU6YRbgG1SFBdlsfNC4/lX+SkhiTs0cpJkOElmWls8PxDFv4yY/xKb8Y6SO0OmSX4wgqTZbA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"undici-types": "~6.21.0"
+			}
+		},
 		"node_modules/acorn": {
 			"version": "8.14.1",
 			"resolved": "https://registry.npmjs.org/acorn/-/acorn-8.14.1.tgz",
@@ -1451,6 +1462,13 @@
 			"engines": {
 				"node": ">=14.17"
 			}
+		},
+		"node_modules/undici-types": {
+			"version": "6.21.0",
+			"resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
+			"integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
+			"dev": true,
+			"license": "MIT"
 		},
 		"node_modules/vite": {
 			"version": "6.3.5",

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
 		"@sveltejs/adapter-auto": "^6.0.0",
 		"@sveltejs/kit": "^2.16.0",
 		"@sveltejs/vite-plugin-svelte": "^5.0.0",
+		"@types/node": "^22.15.30",
 		"prettier": "^3.4.2",
 		"prettier-plugin-svelte": "^3.3.3",
 		"svelte": "^5.0.0",

--- a/src/lib/data/books.ts
+++ b/src/lib/data/books.ts
@@ -1,0 +1,32 @@
+export interface Verse { verse: number; text: string }
+export interface BookData { name: string; chapters: Record<string, Verse[]> }
+
+const modules = import.meta.glob('./books/*.json', { eager: true, query: '?json' }) as Record<string, BookData>
+
+function slugify(name: string) {
+  return name.toLowerCase().replace(/[^a-z0-9]+/g, '-').replace(/^-|-$/g, '')
+}
+
+const map: Record<string, BookData> = {}
+for (const mod of Object.values(modules)) {
+  const slug = slugify(mod.name)
+  map[slug] = mod
+}
+
+export const allBooks = map
+
+export function listBookNames() {
+  return Object.values(map)
+    .map((b) => b.name)
+    .sort((a, b) => a.localeCompare(b))
+}
+
+export function listBooks() {
+  return Object.entries(map)
+    .map(([slug, data]) => ({ slug, name: data.name }))
+    .sort((a, b) => a.name.localeCompare(b.name))
+}
+
+export function getBook(slug: string): BookData | undefined {
+  return map[slugify(slug)]
+}

--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -1,0 +1,19 @@
+<script>
+  let { data, children } = $props();
+</script>
+
+<header class="site-header">
+  <a href="/">Book Flicker</a>
+</header>
+<main>
+  {@render children()}
+</main>
+<footer class="site-footer">&copy; 2025 Book Flicker</footer>
+
+<style>
+  :global(body){margin:0;font-family:sans-serif}
+  .site-header,.site-footer{padding:1rem;text-align:center;background:#f0f0f0}
+  main{padding:1rem;min-height:80vh;margin:0 auto;width:100%}
+  @media (min-width: 1024px){main{width:60%}}
+  a{color:inherit;text-decoration:none}
+</style>

--- a/src/routes/+page.server.ts
+++ b/src/routes/+page.server.ts
@@ -1,0 +1,5 @@
+import { listBooks } from '$lib/data/books';
+
+export function load() {
+  return { books: listBooks() };
+}

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -1,2 +1,16 @@
-<h1>Welcome to SvelteKit</h1>
-<p>Visit <a href="https://svelte.dev/docs/kit">svelte.dev/docs/kit</a> to read the documentation</p>
+<script>
+  let { data } = $props();
+  const { books } = data;
+</script>
+
+<h1>Bible Books</h1>
+<ul class="book-list">
+  {#each books as b}
+    <li><a href={`/book/${b.slug}`}>{b.name}</a></li>
+  {/each}
+</ul>
+
+<style>
+  .book-list{display:grid;grid-template-columns:repeat(auto-fit,minmax(8rem,1fr));gap:.5rem;padding:0;list-style:none}
+  .book-list li{padding:.25rem;background:#eee;text-align:center}
+</style>

--- a/src/routes/book/[book]/+page.server.ts
+++ b/src/routes/book/[book]/+page.server.ts
@@ -1,0 +1,10 @@
+import type { PageServerLoad } from './$types';
+import { getBook } from '$lib/data/books';
+import { error } from '@sveltejs/kit';
+
+export const load: PageServerLoad = ({ params }) => {
+  const data = getBook(params.book);
+  if (!data) throw error(404);
+  const chapters = Object.keys(data.chapters).sort((a, b) => Number(a) - Number(b));
+  return { slug: params.book, book: data.name, chapters };
+};

--- a/src/routes/book/[book]/+page.svelte
+++ b/src/routes/book/[book]/+page.svelte
@@ -1,0 +1,16 @@
+<script lang="ts">
+  let { data } = $props();
+  const { slug, book, chapters } = data;
+</script>
+
+<h1><a href="/">Index</a> / {book}</h1>
+<ul class="chapter-list">
+  {#each chapters as c}
+    <li><a href={`/book/${slug}/${c}`}>Chapter {c}</a></li>
+  {/each}
+</ul>
+
+<style>
+  .chapter-list{display:grid;grid-template-columns:repeat(auto-fit,minmax(6rem,1fr));gap:.5rem;padding:0;list-style:none}
+  .chapter-list li{padding:.25rem;background:#eee;text-align:center}
+</style>

--- a/src/routes/book/[book]/[chapter]/+page.server.ts
+++ b/src/routes/book/[book]/[chapter]/+page.server.ts
@@ -1,0 +1,11 @@
+import type { PageServerLoad } from './$types';
+import { getBook } from '$lib/data/books';
+import { error } from '@sveltejs/kit';
+
+export const load: PageServerLoad = ({ params }) => {
+  const data = getBook(params.book);
+  if (!data) throw error(404);
+  const verses = data.chapters[params.chapter];
+  if (!verses) throw error(404);
+  return { slug: params.book, book: data.name, chapter: params.chapter, verses };
+};

--- a/src/routes/book/[book]/[chapter]/+page.svelte
+++ b/src/routes/book/[book]/[chapter]/+page.svelte
@@ -1,0 +1,37 @@
+<script lang="ts">
+  let { data } = $props();
+  const { slug, book, chapter, verses } = data;
+</script>
+
+<h1><a href="/">Index</a> / <a href={`/book/${slug}`}>{book}</a> / {chapter}</h1>
+
+<div class="carousel">
+  {#each verses as v, i}
+    <article id={`v${i}`} class="slide" data-label={i + 1}>
+      <p class="ref"><a href="/">Index</a> / <a href={`/book/${slug}`}>{book}</a> / {chapter} / {i + 1}</p>
+      <p>{v.text}</p>
+    </article>
+  {/each}
+</div>
+<ol class="markers">
+  {#each verses as _, i}
+    <li><a href={`#v${i}`} aria-label={`Verse ${i + 1}`}></a></li>
+  {/each}
+</ol>
+{@html `<style>${verses.map((_,i)=>`#v${i}:target~.markers li:nth-child(${i+1}) a{background:#333}`).join('')}</style>`}
+
+<style>
+  .carousel{list-style:none;display:grid;grid-auto-flow:column;grid-auto-columns:100%;overflow-x:auto;scroll-snap-type:x mandatory;scrollbar-width:none;padding:0;gap:1rem;position:relative}
+  .carousel::-webkit-scrollbar{display:none}
+  .carousel::scroll-button(left){content:"\2039";left:.5rem}
+  .carousel::scroll-button(right){content:"\203a";right:.5rem}
+  .carousel::scroll-button(left),.carousel::scroll-button(right){position:absolute;top:50%;transform:translateY(-50%);background:#fff;border:1px solid #ccc;border-radius:50%;width:2rem;height:2rem;display:flex;justify-content:center;align-items:center;color:#333}
+  .carousel::scroll-marker-group{display:grid;grid-auto-flow:column;gap:.5rem;position:absolute;left:50%;transform:translateX(-50%);bottom:-1.5rem}
+  .slide{scroll-snap-align:center;padding:1rem}
+  .slide::scroll-marker{content:"";width:.5rem;height:.5rem;background:#ccc;border-radius:50%}
+  .slide::scroll-marker:target-current{background:#333}
+  .markers{display:flex;justify-content:center;list-style:none;padding:0;margin-top:.5rem}
+  .markers li{margin:0 .25rem}
+  .markers a{display:block;width:.75rem;height:.75rem;border-radius:50%;background:#ccc}
+  .markers li:first-child a{background:#333}
+</style>

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -9,8 +9,10 @@
 		"skipLibCheck": true,
 		"sourceMap": true,
 		"strict": true,
-		"moduleResolution": "bundler"
-	}
+        "moduleResolution": "bundler"
+        ,
+        "types": ["node"]
+        }
 	// Path aliases are handled by https://svelte.dev/docs/kit/configuration#alias
 	// except $lib which is handled by https://svelte.dev/docs/kit/configuration#files
 	//


### PR DESCRIPTION
## Summary
- slugify bible book names for URLs
- highlight verse markers in carousel

## Testing
- `npm run lint` (fails: Prettier warnings)
- `npm run check`

------
https://chatgpt.com/codex/tasks/task_e_684337db3294832aafc78550a5995c39