### PR TITLE
Update carousel behavior and URLs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,7 +21,3 @@ Thumbs.db
 # Vite
 vite.config.js.timestamp-*
 vite.config.ts.timestamp-*
-
-.npmrc
-.prettierignore
-.prettierrc

--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,1 @@
+engine-strict=true

--- a/.prettierignore
+++ b/.prettierignore
@@ -1,0 +1,7 @@
+# Package Managers
+package-lock.json
+pnpm-lock.yaml
+yarn.lock
+bun.lock
+bun.lockb
+src/lib/data/books/*.json

--- a/.prettierrc
+++ b/.prettierrc
@@ -1,0 +1,15 @@
+{
+	"useTabs": true,
+	"singleQuote": true,
+	"trailingComma": "none",
+	"printWidth": 100,
+	"plugins": ["prettier-plugin-svelte"],
+	"overrides": [
+		{
+			"files": "*.svelte",
+			"options": {
+				"parser": "svelte"
+			}
+		}
+	]
+}

--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ A simple SvelteKit-based website that lets users flick through a book line by li
 
 ## Technologies
 
-- [SvelteKit](https://kit.svelte.dev/)  
+- [SvelteKit](https://kit.svelte.dev/)
 - Modern CSS (carousel implementation)
 - [OpenAI Codex](https://openai.com/product/codex) for code assistance
+  Enjoy exploring the Bible with Book Flicker.

--- a/src/lib/data/books.ts
+++ b/src/lib/data/books.ts
@@ -1,20 +1,41 @@
-export interface Verse { verse: number; text: string }
-export interface BookData { name: string; chapters: Record<string, Verse[]> }
-
-const modules = import.meta.glob('./books/*.json', { eager: true, as: 'json' }) as Record<string, BookData>
-
-const map: Record<string, BookData> = {}
-for (const [path, mod] of Object.entries(modules)) {
-  const key = path.split('/').pop()?.replace('.json', '') ?? ''
-  map[key] = mod
+export interface Verse {
+	verse: number;
+	text: string;
+}
+export interface BookData {
+	name: string;
+	chapters: Record<string, Verse[]>;
 }
 
-export const allBooks = map
+const modules = import.meta.glob('./books/*.json', { eager: true, as: 'json' }) as Record<
+	string,
+	BookData
+>;
+
+const map: Record<string, BookData> = {};
+for (const [path, mod] of Object.entries(modules)) {
+	const key = path.split('/').pop()?.replace('.json', '') ?? '';
+	map[key] = mod;
+}
+
+export const allBooks = map;
+
+export interface BookInfo {
+	slug: string;
+	name: string;
+}
+
+export function listBooks(): BookInfo[] {
+	return Object.entries(map)
+		.map(([slug, data]) => ({ slug, name: data.name }))
+		.sort((a, b) => a.name.localeCompare(b.name));
+}
 
 export function listBookNames() {
-  return Object.keys(map).sort()
+	return Object.keys(map).sort();
 }
 
 export function getBook(name: string): BookData | undefined {
-  return map[name]
+	const key = name.replace(/\s+/g, '');
+	return map[key];
 }

--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -1,18 +1,38 @@
 <script>
-  let { data } = $props();
+	let { data } = $props();
 </script>
 
 <header class="site-header">
-  <a href="/">Book Flicker</a>
+	<a href="/">Book Flicker</a>
 </header>
 <main>
-  <slot />
+	<slot />
 </main>
 <footer class="site-footer">&copy; 2025 Book Flicker</footer>
 
 <style>
-  :global(body){margin:0;font-family:sans-serif}
-  .site-header,.site-footer{padding:1rem;text-align:center;background:#f0f0f0}
-  main{padding:1rem;min-height:80vh}
-  a{color:inherit;text-decoration:none}
+	:global(body) {
+		margin: 0;
+		font-family: sans-serif;
+	}
+	.site-header,
+	.site-footer {
+		padding: 1rem;
+		text-align: center;
+		background: #f0f0f0;
+	}
+	main {
+		padding: 1rem;
+		min-height: 80vh;
+	}
+	@media (min-width: 768px) {
+		main {
+			width: 60%;
+			margin: 0 auto;
+		}
+	}
+	a {
+		color: inherit;
+		text-decoration: none;
+	}
 </style>

--- a/src/routes/+page.server.ts
+++ b/src/routes/+page.server.ts
@@ -1,5 +1,5 @@
-import { listBookNames } from '$lib/data/books';
+import { listBooks } from '$lib/data/books';
 
 export function load() {
-  return { books: listBookNames() };
+	return { books: listBooks() };
 }

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -1,16 +1,26 @@
 <script>
-  let { data } = $props();
-  const { books } = data;
+	let { data } = $props();
+	const { books } = data;
 </script>
 
 <h1>Bible Books</h1>
 <ul class="book-list">
-  {#each books as b}
-    <li><a href={`/book/${b}`}>{b}</a></li>
-  {/each}
+	{#each books as b}
+		<li><a href={`/book/${b.slug}`}>{b.name}</a></li>
+	{/each}
 </ul>
 
 <style>
-  .book-list{display:grid;grid-template-columns:repeat(auto-fit,minmax(8rem,1fr));gap:.5rem;padding:0;list-style:none}
-  .book-list li{padding:.25rem;background:#eee;text-align:center}
+	.book-list {
+		display: grid;
+		grid-template-columns: repeat(auto-fit, minmax(8rem, 1fr));
+		gap: 0.5rem;
+		padding: 0;
+		list-style: none;
+	}
+	.book-list li {
+		padding: 0.25rem;
+		background: #eee;
+		text-align: center;
+	}
 </style>

--- a/src/routes/book/[book]/+page.server.ts
+++ b/src/routes/book/[book]/+page.server.ts
@@ -3,8 +3,8 @@ import { getBook } from '$lib/data/books';
 import { error } from '@sveltejs/kit';
 
 export const load: PageServerLoad = ({ params }) => {
-  const data = getBook(params.book);
-  if (!data) throw error(404);
-  const chapters = Object.keys(data.chapters).sort((a, b) => Number(a) - Number(b));
-  return { book: data.name, chapters };
+	const data = getBook(params.book);
+	if (!data) throw error(404);
+	const chapters = Object.keys(data.chapters).sort((a, b) => Number(a) - Number(b));
+	return { book: data.name, slug: params.book, chapters };
 };

--- a/src/routes/book/[book]/+page.svelte
+++ b/src/routes/book/[book]/+page.svelte
@@ -1,16 +1,26 @@
 <script lang="ts">
-  let { data } = $props();
-  const { book, chapters } = data;
+	let { data } = $props();
+	const { book, slug, chapters } = data;
 </script>
 
 <h1><a href="/">Index</a> / {book}</h1>
 <ul class="chapter-list">
-  {#each chapters as c}
-    <li><a href={`/book/${book}/${c}`}>Chapter {c}</a></li>
-  {/each}
+	{#each chapters as c}
+		<li><a href={`/book/${slug}/${c}`}>Chapter {c}</a></li>
+	{/each}
 </ul>
 
 <style>
-  .chapter-list{display:grid;grid-template-columns:repeat(auto-fit,minmax(6rem,1fr));gap:.5rem;padding:0;list-style:none}
-  .chapter-list li{padding:.25rem;background:#eee;text-align:center}
+	.chapter-list {
+		display: grid;
+		grid-template-columns: repeat(auto-fit, minmax(6rem, 1fr));
+		gap: 0.5rem;
+		padding: 0;
+		list-style: none;
+	}
+	.chapter-list li {
+		padding: 0.25rem;
+		background: #eee;
+		text-align: center;
+	}
 </style>

--- a/src/routes/book/[book]/[chapter]/+page.server.ts
+++ b/src/routes/book/[book]/[chapter]/+page.server.ts
@@ -3,9 +3,9 @@ import { getBook } from '$lib/data/books';
 import { error } from '@sveltejs/kit';
 
 export const load: PageServerLoad = ({ params }) => {
-  const data = getBook(params.book);
-  if (!data) throw error(404);
-  const verses = data.chapters[params.chapter];
-  if (!verses) throw error(404);
-  return { book: data.name, chapter: params.chapter, verses };
+	const data = getBook(params.book);
+	if (!data) throw error(404);
+	const verses = data.chapters[params.chapter];
+	if (!verses) throw error(404);
+	return { book: data.name, slug: params.book, chapter: params.chapter, verses };
 };

--- a/src/routes/book/[book]/[chapter]/+page.svelte
+++ b/src/routes/book/[book]/[chapter]/+page.svelte
@@ -1,41 +1,92 @@
 <script lang="ts">
-  let { data } = $props();
-  const { book, chapter, verses } = data;
-  const highlight = verses
-    .map((_, i) => `#v${i}:target ~ .markers li:nth-child(${i + 1}) a{background:#333}`)
-    .join('');
+	let { data } = $props();
+	const { book, slug, chapter, verses } = data;
+	const highlight = [
+		'.carousel:not(:has(article:target)) + .markers li:first-child a{background:#333}',
+		...verses.map(
+			(_, i) => `.carousel:has(#v${i}:target) + .markers li:nth-child(${i + 1}) a{background:#333}`
+		)
+	].join('');
 </script>
 
-<h1><a href="/">Index</a> / <a href={`/book/${book}`}>{book}</a> / {chapter}</h1>
+<h1><a href="/">Index</a> / <a href={`/book/${slug}`}>{book}</a> / {chapter}</h1>
 <div class="carousel-wrap">
-  <div class="carousel">
-    {#each verses as v, i}
-      <article id={`v${i}`} class="slide">
-        <p class="ref"><a href="/">Index</a> / <a href={`/book/${book}`}>{book}</a> / {chapter} / {i + 1}</p>
-        <p>{v.text}</p>
-        <a class="nav prev" href={`#v${i === 0 ? 0 : i - 1}`}>‹</a>
-        <a class="nav next" href={`#v${i === verses.length - 1 ? i : i + 1}`}>›</a>
-      </article>
-    {/each}
-  </div>
+	<div class="carousel">
+		{#each verses as v, i}
+			<article id={`v${i}`} class="slide">
+				<p>{v.text}</p>
+				<a class="nav prev" href={`#v${i === 0 ? 0 : i - 1}`}>‹</a>
+				<a class="nav next" href={`#v${i === verses.length - 1 ? i : i + 1}`}>›</a>
+			</article>
+		{/each}
+	</div>
 </div>
 <ol class="markers">
-  {#each verses as _, i}
-    <li><a href={`#v${i}`}></a></li>
-  {/each}
+	{#each verses as _, i}
+		<li><a href={`#v${i}`}></a></li>
+	{/each}
 </ol>
+{@html `<style>${highlight}</style>`}
 
 <style>
-  .carousel-wrap{position:relative}
-  .carousel{display:flex;overflow-x:auto;scroll-snap-type:x mandatory;scroll-behavior:smooth}
-  .slide{flex:0 0 100%;scroll-snap-align:center;padding:1rem;box-sizing:border-box;position:relative}
-  .nav{position:absolute;top:50%;transform:translateY(-50%);font-size:2rem;padding:0 .5rem;text-decoration:none;color:inherit}
-  .prev{left:0}
-  .next{right:0}
-  .slide:not(:target) .nav{display:none}
-  .markers{display:flex;justify-content:center;list-style:none;padding:0;margin-top:.5rem}
-  .markers li{margin:0 .25rem}
-  .markers a{display:block;width:.75rem;height:.75rem;border-radius:50%;background:#ccc}
-  .markers li:first-child a{background:#333}
+	.carousel-wrap {
+		position: relative;
+	}
+	.carousel {
+		position: relative;
+	}
+	.slide {
+		position: absolute;
+		inset: 0;
+		padding: 1rem;
+		box-sizing: border-box;
+		opacity: 0;
+		transition: opacity 0.3s;
+		pointer-events: none;
+	}
+	.carousel:not(:has(article:target)) > .slide:first-child,
+	.slide:target {
+		opacity: 1;
+		position: relative;
+		pointer-events: auto;
+	}
+	.nav {
+		position: absolute;
+		top: 50%;
+		transform: translateY(-50%);
+		font-size: 3rem;
+		padding: 0 0.5rem;
+		margin: 0 0.5rem;
+		text-decoration: none;
+		color: inherit;
+	}
+	.prev {
+		left: -1.5rem;
+	}
+	.next {
+		right: -1.5rem;
+	}
+	.slide:not(:target) .nav {
+		display: none;
+	}
+	.carousel:not(:has(article:target)) .slide:first-child .nav {
+		display: block;
+	}
+	.markers {
+		display: flex;
+		justify-content: center;
+		list-style: none;
+		padding: 0;
+		margin-top: 0.5rem;
+	}
+	.markers li {
+		margin: 0 0.25rem;
+	}
+	.markers a {
+		display: block;
+		width: 0.75rem;
+		height: 0.75rem;
+		border-radius: 50%;
+		background: #ccc;
+	}
 </style>
-{@html `<style>${highlight}</style>`}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -9,10 +9,9 @@
 		"skipLibCheck": true,
 		"sourceMap": true,
 		"strict": true,
-        "moduleResolution": "bundler"
-        ,
-        "types": ["node"]
-        }
+		"moduleResolution": "bundler",
+		"types": ["node"]
+	}
 	// Path aliases are handled by https://svelte.dev/docs/kit/configuration#alias
 	// except $lib which is handled by https://svelte.dev/docs/kit/configuration#files
 	//


### PR DESCRIPTION
## Summary
- add `listBooks` helper and return slugs with display names
- use slugs in links for cleaner URLs
- show navigation arrows on load, enlarge them, and offset from carousel
- fade between verses in carousel and remove internal breadcrumbs
- ignore large data files for Prettier; format README

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_684375e01cc4832a81474f80e4ab078f