### PR TITLE
Improve carousel UI and URL handling

### DIFF
--- a/src/routes/book/[book]/+page.server.ts
+++ b/src/routes/book/[book]/+page.server.ts
@@ -6,5 +6,5 @@ export const load: PageServerLoad = ({ params }) => {
   const data = getBook(params.book);
   if (!data) throw error(404);
   const chapters = Object.keys(data.chapters).sort((a, b) => Number(a) - Number(b));
-  return { book: data.name, chapters };
+  return { book: data.name, slug: params.book, chapters };
 };

--- a/src/routes/book/[book]/+page.svelte
+++ b/src/routes/book/[book]/+page.svelte
@@ -1,12 +1,12 @@
 <script lang="ts">
   let { data } = $props();
-  const { book, chapters } = data;
+  const { book, slug, chapters } = data;
 </script>
 
 <h1><a href="/">Index</a> / {book}</h1>
 <ul class="chapter-list">
   {#each chapters as c}
-    <li><a href={`/book/${book}/${c}`}>Chapter {c}</a></li>
+    <li><a href={`/book/${slug}/${c}`}>Chapter {c}</a></li>
   {/each}
 </ul>
 

--- a/src/routes/book/[book]/[chapter]/+page.server.ts
+++ b/src/routes/book/[book]/[chapter]/+page.server.ts
@@ -7,5 +7,5 @@ export const load: PageServerLoad = ({ params }) => {
   if (!data) throw error(404);
   const verses = data.chapters[params.chapter];
   if (!verses) throw error(404);
-  return { book: data.name, chapter: params.chapter, verses };
+  return { book: data.name, slug: params.book, chapter: params.chapter, verses };
 };

--- a/src/routes/book/[book]/[chapter]/+page.svelte
+++ b/src/routes/book/[book]/[chapter]/+page.svelte
@@ -1,90 +1,92 @@
 <script lang="ts">
-	let { data } = $props();
-	const { book, chapter, verses } = data;
-	const highlight = [
-		'.carousel:not(:has(article:target)) + .markers li:first-child a{background:#333}',
-		...verses.map(
-			(_, i) => `.carousel:has(#v${i}:target) + .markers li:nth-child(${i + 1}) a{background:#333}`
-		)
-	].join('');
+  let { data } = $props();
+  const { book, slug, chapter, verses } = data;
+  let current = 0;
+
+  function goTo(i: number) {
+    current = i;
+  }
 </script>
 
-<h1><a href="/">Index</a> / <a href={`/book/${book}`}>{book}</a> / {chapter}</h1>
+<h1><a href="/">Index</a> / <a href={`/book/${slug}`}>{book}</a> / {chapter}</h1>
 <div class="carousel-wrap">
-	<div class="carousel">
-		{#each verses as v, i}
-			<article id={`v${i}`} class="slide">
-				<p class="ref">
-					<a href="/">Index</a> / <a href={`/book/${book}`}>{book}</a> / {chapter} / {i + 1}
-				</p>
-				<p>{v.text}</p>
-				<a class="nav prev" href={`#v${i === 0 ? 0 : i - 1}`}>‹</a>
-				<a class="nav next" href={`#v${i === verses.length - 1 ? i : i + 1}`}>›</a>
-			</article>
-		{/each}
-	</div>
+  <div class="carousel" style={`transform:translateX(-${current * 100}%);`}>
+    {#each verses as v, i}
+      <article class="slide">{v.text}</article>
+    {/each}
+  </div>
+  <a
+    class="nav prev"
+    href="#"
+    on:click|preventDefault={() => goTo(Math.max(0, current - 1))}
+    >‹</a
+  >
+  <a
+    class="nav next"
+    href="#"
+    on:click|preventDefault={() => goTo(Math.min(verses.length - 1, current + 1))}
+    >›</a
+  >
 </div>
 <ol class="markers">
-	{#each verses as _, i}
-		<li><a href={`#v${i}`}></a></li>
-	{/each}
+  {#each verses as _, i}
+    <li>
+      <a
+        href="#"
+        class:selected={i === current}
+        on:click|preventDefault={() => goTo(i)}
+      ></a>
+    </li>
+  {/each}
 </ol>
-{@html `<style>${highlight}</style>`}
 
 <style>
-	.carousel-wrap {
-		position: relative;
-	}
-	.carousel {
-		display: flex;
-		overflow-x: auto;
-		scroll-snap-type: x mandatory;
-		scroll-behavior: smooth;
-		scrollbar-width: none;
-	}
-	.carousel::-webkit-scrollbar {
-		display: none;
-	}
-	.slide {
-		flex: 0 0 100%;
-		scroll-snap-align: center;
-		padding: 1rem;
-		box-sizing: border-box;
-		position: relative;
-	}
-	.nav {
-		position: absolute;
-		top: 50%;
-		transform: translateY(-50%);
-		font-size: 2rem;
-		padding: 0 0.5rem;
-		text-decoration: none;
-		color: inherit;
-	}
-	.prev {
-		left: 0;
-	}
-	.next {
-		right: 0;
-	}
-	.slide:not(:target) .nav {
-		display: none;
-	}
-	.markers {
-		display: flex;
-		justify-content: center;
-		list-style: none;
-		padding: 0;
-		margin-top: 0.5rem;
-	}
-	.markers li {
-		margin: 0 0.25rem;
-	}
-	.markers a {
-		display: block;
-		width: 0.75rem;
-		height: 0.75rem;
-		border-radius: 50%;
-		background: #ccc;
-	}
+        .carousel-wrap {
+                position: relative;
+        }
+        .carousel {
+                display: flex;
+                overflow: hidden;
+                transition: transform 0.4s ease;
+        }
+        .slide {
+                flex: 0 0 100%;
+                padding: 1rem;
+                box-sizing: border-box;
+        }
+        .nav {
+                position: absolute;
+                top: 50%;
+                transform: translateY(-50%);
+                font-size: 3rem;
+                padding: 0 0.5rem;
+                text-decoration: none;
+                color: inherit;
+        }
+        .prev {
+                left: -1.5rem;
+        }
+        .next {
+                right: -1.5rem;
+        }
+        .markers {
+                display: flex;
+                justify-content: center;
+                list-style: none;
+                padding: 0;
+                margin-top: 0.5rem;
+        }
+        .markers li {
+                margin: 0 0.25rem;
+        }
+        .markers a {
+                display: block;
+                width: 0.75rem;
+                height: 0.75rem;
+                border-radius: 50%;
+                background: #ccc;
+        }
+        .markers a.selected {
+                background: #666;
+        }
 </style>


### PR DESCRIPTION
## Summary
- keep verse navigation arrows visible and reposition them outside the carousel
- highlight active verse marker
- animate verse changes with a sliding transform
- tidy breadcrumbs and use slug values for navigation

## Testing
- `npm run lint` *(fails: Cannot find package 'prettier-plugin-svelte')*
- `npm run check` *(fails: svelte-kit not found)*

------
https://chatgpt.com/codex/tasks/task_e_6844653141dc832ab9c362697de59239