### PR TITLE
Fix carousel for Svelte 5

### DIFF
--- a/src/routes/book/[book]/[chapter]/+page.svelte
+++ b/src/routes/book/[book]/[chapter]/+page.svelte
@@ -1,73 +1,80 @@
 <script lang="ts">
   let { data } = $props();
   const { book, slug, chapter, verses } = data;
-  let current = 0;
 
-  function goTo(i: number) {
-    current = i;
-  }
+  const highlight = [
+    '.carousel:not(:has(article:target)) + .markers li:first-child a{background:#333}',
+    ...verses.map(
+      (_, i) => `.carousel:has(#v${i}:target) + .markers li:nth-child(${i + 1}) a{background:#333}`
+    )
+  ].join('');
 </script>
 
 <h1><a href="/">Index</a> / <a href={`/book/${slug}`}>{book}</a> / {chapter}</h1>
 <div class="carousel-wrap">
-  <div class="carousel" style={`transform:translateX(-${current * 100}%);`}>
+  <div class="carousel">
     {#each verses as v, i}
-      <article class="slide">{v.text}</article>
+      <article id={`v${i}`} class="slide">
+        <p class="ref">
+          <a href="/">Index</a> / <a href={`/book/${slug}`}>{book}</a> / {chapter} / {i + 1}
+        </p>
+        <p>{v.text}</p>
+        <a class="nav prev" href={`#v${i === 0 ? 0 : i - 1}`}>‹</a>
+        <a class="nav next" href={`#v${i === verses.length - 1 ? i : i + 1}`}>›</a>
+      </article>
     {/each}
   </div>
-  <a
-    class="nav prev"
-    href="#"
-    on:click|preventDefault={() => goTo(Math.max(0, current - 1))}
-    >‹</a
-  >
-  <a
-    class="nav next"
-    href="#"
-    on:click|preventDefault={() => goTo(Math.min(verses.length - 1, current + 1))}
-    >›</a
-  >
 </div>
 <ol class="markers">
   {#each verses as _, i}
-    <li>
-      <a
-        href="#"
-        class:selected={i === current}
-        on:click|preventDefault={() => goTo(i)}
-      ></a>
-    </li>
+    <li><a href={`#v${i}`}></a></li>
   {/each}
 </ol>
+{@html `<style>${highlight}</style>`}
 
 <style>
         .carousel-wrap {
                 position: relative;
         }
         .carousel {
-                display: flex;
-                overflow: hidden;
-                transition: transform 0.4s ease;
+                list-style: none;
+                margin: 0;
+                padding: 0;
+                display: grid;
+                grid-auto-flow: column;
+                grid-auto-columns: 100%;
+                gap: 1rem;
+                overflow-x: auto;
+                scroll-snap-type: x mandatory;
+                scroll-behavior: smooth;
+                scrollbar-width: none;
+        }
+        .carousel::-webkit-scrollbar {
+                display: none;
         }
         .slide {
-                flex: 0 0 100%;
+                scroll-snap-align: center;
                 padding: 1rem;
                 box-sizing: border-box;
+                position: relative;
         }
         .nav {
                 position: absolute;
                 top: 50%;
                 transform: translateY(-50%);
-                font-size: 3rem;
+                font-size: 2rem;
                 padding: 0 0.5rem;
                 text-decoration: none;
                 color: inherit;
         }
         .prev {
-                left: -1.5rem;
+                left: 0;
         }
         .next {
-                right: -1.5rem;
+                right: 0;
+        }
+        .slide:not(:target) .nav {
+                display: none;
         }
         .markers {
                 display: flex;
@@ -85,8 +92,5 @@
                 height: 0.75rem;
                 border-radius: 50%;
                 background: #ccc;
-        }
-        .markers a.selected {
-                background: #666;
         }
 </style>


### PR DESCRIPTION
## Summary
- generate CSS for active marker highlighting in one `<style>` block
- use grid based layout for the carousel so anchors scroll smoothly
- keep CSS-only navigation without JavaScript

## Testing
- `npm run lint`
- `npm run check`
- `npm run build`
- `git pull origin main` *(fails: remote not found)*

------
https://chatgpt.com/codex/tasks/task_e_68446cc01bb0832abab90cd66ec69344