### PR TITLE
Implement CSS-only carousel

### DIFF
--- a/src/routes/book/[book]/[chapter]/+page.svelte
+++ b/src/routes/book/[book]/[chapter]/+page.svelte
@@ -1,92 +1,108 @@
 <script lang="ts">
   let { data } = $props();
   const { book, slug, chapter, verses } = data;
-  let current = 0;
-
-  function goTo(i: number) {
-    current = i;
-  }
 </script>
 
 <h1><a href="/">Index</a> / <a href={`/book/${slug}`}>{book}</a> / {chapter}</h1>
-<div class="carousel-wrap">
-  <div class="carousel" style={`transform:translateX(-${current * 100}%);`}>
-    {#each verses as v, i}
-      <article class="slide">{v.text}</article>
-    {/each}
-  </div>
-  <a
-    class="nav prev"
-    href="#"
-    on:click|preventDefault={() => goTo(Math.max(0, current - 1))}
-    >‹</a
-  >
-  <a
-    class="nav next"
-    href="#"
-    on:click|preventDefault={() => goTo(Math.min(verses.length - 1, current + 1))}
-    >›</a
-  >
-</div>
-<ol class="markers">
-  {#each verses as _, i}
-    <li>
-      <a
-        href="#"
-        class:selected={i === current}
-        on:click|preventDefault={() => goTo(i)}
-      ></a>
-    </li>
+<div
+  class="carousel carousel--scroll-markers carousel--scroll-buttons"
+  role="region"
+  aria-label="Chapter {chapter}"
+>
+  {#each verses as v, i}
+    <article class="carousel__slide" data-label={`Verse ${i + 1}`}> 
+      <p class="ref">Index / {book} / {chapter} / {i + 1}</p>
+      <p>{v.text}</p>
+    </article>
   {/each}
-</ol>
+</div>
 
 <style>
-        .carousel-wrap {
-                position: relative;
-        }
-        .carousel {
-                display: flex;
-                overflow: hidden;
-                transition: transform 0.4s ease;
-        }
-        .slide {
-                flex: 0 0 100%;
-                padding: 1rem;
-                box-sizing: border-box;
-        }
-        .nav {
-                position: absolute;
-                top: 50%;
-                transform: translateY(-50%);
-                font-size: 3rem;
-                padding: 0 0.5rem;
-                text-decoration: none;
-                color: inherit;
-        }
-        .prev {
-                left: -1.5rem;
-        }
-        .next {
-                right: -1.5rem;
-        }
-        .markers {
-                display: flex;
-                justify-content: center;
-                list-style: none;
-                padding: 0;
-                margin-top: 0.5rem;
-        }
-        .markers li {
-                margin: 0 0.25rem;
-        }
-        .markers a {
-                display: block;
-                width: 0.75rem;
-                height: 0.75rem;
-                border-radius: 50%;
-                background: #ccc;
-        }
-        .markers a.selected {
-                background: #666;
-        }
+  .carousel {
+    list-style-type: none;
+    margin: 0;
+    padding: 0;
+    position: relative;
+    display: grid;
+    grid-auto-flow: column;
+    grid-auto-columns: 100%;
+    gap: 1rem;
+    overflow-x: auto;
+    scroll-snap-type: x mandatory;
+    scrollbar-width: none;
+    scroll-padding-inline: 1rem;
+  }
+
+  @media (prefers-reduced-motion: no-preference) {
+    .carousel {
+      scroll-behavior: smooth;
+    }
+  }
+
+  .carousel--scroll-markers {
+    &::scroll-marker-group {
+      position: absolute;
+      bottom: 0;
+      left: 50%;
+      transform: translateX(-50%);
+      display: flex;
+      gap: 4px;
+      padding: 5px 10px;
+      block-size: 44px;
+      inline-size: 50px;
+    }
+  
+    .carousel__slide::scroll-marker {
+      content: "";
+      inline-size: 10px;
+      aspect-ratio: 1;
+      border: 1px solid #999;
+      border-radius: 50%;
+      background: #ccc;
+    }
+
+    .carousel__slide::scroll-marker:target-current {
+      background: #333;
+      border-color: #333;
+    }
+  }
+
+  .carousel--scroll-buttons {
+    &::scroll-button(left),
+    &::scroll-button(right) {
+      position: absolute;
+      top: 50%;
+      transform: translateY(-50%);
+      inline-size: 44px;
+      aspect-ratio: 1;
+      display: grid;
+      place-content: center;
+      background: white;
+      border: 1px solid #999;
+      border-radius: 50%;
+      font-size: 1.25rem;
+    }
+
+    &::scroll-button(left) {
+      content: "\2039";
+      left: 0;
+    }
+
+    &::scroll-button(right) {
+      content: "\203A";
+      right: 0;
+    }
+  }
+
+  .carousel::-webkit-scrollbar {
+    display: none;
+  }
+
+  .carousel__slide {
+    container-type: scroll-state;
+    scroll-snap-align: center;
+    scroll-snap-stop: always;
+    padding: 1rem;
+    box-sizing: border-box;
+  }
 </style>


### PR DESCRIPTION
## Summary
- rework chapter carousel markup
- add pure CSS scroll markers and buttons

## Testing
- `npm run lint` *(fails: prettier-plugin-svelte missing)*
- `npm run check` *(fails: svelte-kit not found)*
- `npm run build` *(fails: vite not found)*
- `git pull origin main` *(fails: remote repository not found)*

------
https://chatgpt.com/codex/tasks/task_e_68446cc01bb0832abab90cd66ec69344